### PR TITLE
Add logic to login to shotgrid using scrip_name and key.

### DIFF
--- a/client/ayon_shotgrid/addon.py
+++ b/client/ayon_shotgrid/addon.py
@@ -1,4 +1,5 @@
 import os
+import ayon_api
 
 from openpype.modules import (
     OpenPypeModule,
@@ -17,7 +18,7 @@ class ShotgridAddon(OpenPypeModule, ITrayModule, IPluginPaths):
     def initialize(self, modules_settings):
         module_settings = modules_settings.get(self.name, dict())
         self._shotgrid_server_url = module_settings.get("shotgrid_server")
-        self._shotgrid_script_name = None
+        self._shotgrid_script_name = module_settings.get("shotgrid_script_name")
         self._shotgrid_api_key = None
 
     def get_sg_url(self):
@@ -35,14 +36,20 @@ class ShotgridAddon(OpenPypeModule, ITrayModule, IPluginPaths):
 
         sg_username, sg_password = credentials.get_local_login()
 
-        if not sg_username or not sg_password:
+        secret = self.get_shotgrid_secret_data()
+        login_args = {'base_url': self._shotgrid_server_url}
+        if secret:
+            login_args['script_name'] = secret.get('name')
+            login_args['api_key'] = secret.get('value')
+            login_args['sudo_as_login'] = sg_username
+        else:
+            login_args['login'] = sg_username
+            login_args['password'] = sg_password
+
+        if not any(login_args.values()):
             return None
 
-        return credentials.create_sg_session(
-            self._shotgrid_server_url,
-            sg_username,
-            sg_password
-        )
+        return credentials.create_sg_session(**login_args)
 
     def tray_init(self):
         from .tray.shotgrid_tray import ShotgridTrayWrapper
@@ -56,3 +63,19 @@ class ShotgridAddon(OpenPypeModule, ITrayModule, IPluginPaths):
 
     def tray_menu(self, tray_menu):
         return self.tray_wrapper.tray_menu(tray_menu)
+
+    def get_shotgrid_secret_data(self):
+        """Gets shotgrid data from server for login.
+
+        Returns:
+            (dict): script_name under 'name' key and api_key under 'value' key.
+
+        """
+        ayon_server_api = ayon_api.get_server_api_connection()
+
+        secret = ''
+        try:
+            secret = ayon_server_api.get_secret(self._shotgrid_script_name)
+            return secret
+        except ayon_api.exceptions.HTTPRequestError:
+            return secret

--- a/client/ayon_shotgrid/addon.py
+++ b/client/ayon_shotgrid/addon.py
@@ -18,7 +18,7 @@ class ShotgridAddon(OpenPypeModule, ITrayModule, IPluginPaths):
     def initialize(self, modules_settings):
         module_settings = modules_settings.get(self.name, dict())
         self._shotgrid_server_url = module_settings.get("shotgrid_server")
-        self._shotgrid_script_name = module_settings.get("shotgrid_script_name")
+        self._shotgrid_script_name = module_settings.get("shotgrid_api_secret")
         self._shotgrid_api_key = None
 
     def get_sg_url(self):

--- a/client/ayon_shotgrid/lib/credentials.py
+++ b/client/ayon_shotgrid/lib/credentials.py
@@ -4,28 +4,27 @@ from shotgun_api3.shotgun import AuthenticationFault
 from openpype.lib import OpenPypeSettingsRegistry
 
 
-def check_user_permissions(shotgrid_url, username, password):
+def check_user_permissions(**kwargs):
     """Check if the provided user can access the Shotgrid API.
 
     Args:
-        shotgrid_url (str): The Shotgun server URL.
-        username (str): The Shotgrid login username.
+        base_url (str): The Shotgun server URL.
+        login (str): The Shotgrid login username.
         password (str): The Shotgrid login password.
+        script_name (str): Name of the Shotgrid script name used for login.
+        api_key (str): key related to shotgrid script name.
+        sudo_as_login (str): The Shotgrid login username.
         
     Returns:
         tuple(bool, str): Whether the connection was succsefull or not, and a 
             string message with the result.
      """
-    
-    if not shotgrid_url or not username or not password:
+    if not any(kwargs.values()):
+        print('check_user_permissions: ', kwargs)
         return (False, "Missing a field.")
 
     try:
-        session = create_sg_session(
-            shotgrid_url,
-            username,
-            password
-        )
+        session = create_sg_session(**kwargs)
         session.close()
     except AuthenticationFault as e:
         return (False, str(e))
@@ -39,14 +38,16 @@ def clear_local_login():
     reg.delete_item("shotgrid_login")
 
 
-def create_sg_session(shotgrid_url, username, password):
+def create_sg_session(**kwargs):
     """Attempt to create a Shotgun Session
 
     Args:
-        shotgrid_url (str): The Shotgun server URL.
-        script_name (str): The Shotgrid API script name.
-        api_key (str): The Shotgrid API key.
-        username (str): The Shotgrid username to use the Session as.
+        base_url (str): The Shotgun server URL.
+        login (str): The Shotgrid login username.
+        password (str): The Shotgrid login password.
+        script_name (str): Name of the Shotgrid script name used for login.
+        api_key (str): key related to shotgrid script name.
+        sudo_as_login (str): The Shotgrid login username.
 
     Returns:
         session (shotgun_api3.Shotgun): A Shotgrid API Session.
@@ -55,11 +56,7 @@ def create_sg_session(shotgrid_url, username, password):
         AuthenticationFault: If the authentication with Shotgrid fails.
     """
 
-    session = shotgun_api3.Shotgun(
-        base_url=shotgrid_url,
-        login=username,
-        password=password,
-    )
+    session = shotgun_api3.Shotgun(**kwargs)
 
     session.preferences_read()
 

--- a/version.py
+++ b/version.py
@@ -1,3 +1,3 @@
 # -*- coding: utf-8 -*-
 """Package declaring addon version."""
-__version__ = "0.2.9"
+__version__ = "0.3.0"


### PR DESCRIPTION
This is based on an issue described here:
https://marzvfx.atlassian.net/browse/AYON-2

The goal is to be able to login into shotgrid by using an script under users name, this way we can still use 2FA to keep it safe.

I tested it in my side today by login into shotgrid using the "Shotgrid" option in the tray / launcher, it should login with no issues, the second part is to try to publish something, I tried using the following context and you can see there is a publish file (version 6) created today.
![image](https://github.com/ynput/ayon-shotgrid/assets/73557815/1099bc63-c49e-44f9-9ee0-309cdd904986)
